### PR TITLE
Enable streaming STT with hotword detection

### DIFF
--- a/Wheatly/python/src/main.py
+++ b/Wheatly/python/src/main.py
@@ -171,13 +171,15 @@ def print_event(event: Event):
     print(event)
 
 async def hotword_listener(queue, stt_engine):
-    """Background task: waits for hotword, records and transcribes, puts as user event."""
+    """Background task using streaming STT triggered by a hotword."""
     print("[Hotword] Background listener started.")
     loop = asyncio.get_event_loop()
     try:
         while True:
-            # Run the blocking get_voice_input in a thread
-            text = await loop.run_in_executor(None, stt_engine.get_voice_input)
+            # Run the blocking live voice input workflow in a thread
+            text = await loop.run_in_executor(
+                None, stt_engine.get_live_voice_input_blocking
+            )
             if text and text.strip():
                 await queue.put(Event("user", text.strip()))
     except Exception as e:

--- a/Wheatly/python/src/stt/stt_engine.py
+++ b/Wheatly/python/src/stt/stt_engine.py
@@ -607,6 +607,15 @@ class SpeechToTextEngine:
         # Return combined results
         return " ".join(transcription_results)
 
+    def get_live_voice_input_blocking(self, duration_seconds=30, use_chunked=True):
+        """Synchronous wrapper around ``get_live_voice_input``.
+
+        This allows the live transcription workflow to be executed from a
+        background thread using ``run_in_executor`` without blocking the main
+        asyncio event loop.
+        """
+        return asyncio.run(self.get_live_voice_input(duration_seconds, use_chunked))
+
     def get_voice_input(self):
         """
         Waits for hotword, then records and transcribes speech.


### PR DESCRIPTION
## Summary
- add helper to run live voice input in blocking mode
- switch hotword listener to use streaming transcription

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68428aa893ec833096c2e4c9a860b70c