### PR TITLE
Handle STT pause during TTS

### DIFF
--- a/Wheatly/python/src/main.py
+++ b/Wheatly/python/src/main.py
@@ -270,7 +270,28 @@ async def async_conversation_loop(manager, gpt_client, stt_engine, tts_engine, a
             print(Fore.GREEN + Style.BRIGHT + f"\nAssistant: {gpt_text}" + Style.RESET_ALL)
             print(Fore.LIGHTBLACK_EX + Style.BRIGHT + "\n»»» Ready for your input! Type below..." + Style.RESET_ALL)
             if tts_enabled:
+                # Pause hotword listener while TTS is playing
+                if hotword_task:
+                    hotword_task.cancel()
+                    await asyncio.gather(hotword_task, return_exceptions=True)
+                    print("[STT] Hotword listener paused.")
+                    hotword_task = None
+
                 tts_engine.generate_and_play_advanced(gpt_text)
+
+                if stt_enabled:
+                    print("[STT] Listening for follow-up without hotword for 10 seconds...")
+                    loop = asyncio.get_event_loop()
+                    follow_up = await loop.run_in_executor(
+                        None,
+                        lambda: stt_engine.get_live_voice_input_blocking(10, True, False)
+                    )
+                    if follow_up and follow_up.strip():
+                        await queue.put(Event("user", follow_up.strip()))
+
+                if stt_enabled:
+                    hotword_task = asyncio.create_task(hotword_listener(queue, stt_engine))
+                    print("[STT] Hotword listener resumed.")
     except (asyncio.CancelledError, KeyboardInterrupt):
         print("\n[Main] KeyboardInterrupt or CancelledError received. Exiting...")
     finally:

--- a/Wheatly/python/src/stt/stt_engine.py
+++ b/Wheatly/python/src/stt/stt_engine.py
@@ -565,14 +565,18 @@ class SpeechToTextEngine:
 
         return None
 
-    async def get_live_voice_input(self, duration_seconds=30, use_chunked=True):
+    async def get_live_voice_input(self, duration_seconds=30, use_chunked=True, require_hotword=True):
         """
-        Waits for hotword, then starts live transcription for specified duration.
-        Returns the final transcribed text.
+        Waits for hotword (unless ``require_hotword`` is False), then starts
+        live transcription for ``duration_seconds``. Returns the final
+        transcribed text.
         """
-        idx = self.listen_for_hotword()
-        if idx is None:
-            return ""
+        if require_hotword:
+            idx = self.listen_for_hotword()
+            if idx is None:
+                return ""
+        else:
+            print(f"[STT] Listening for speech for {duration_seconds} seconds...")
         
         print(f"Starting live transcription for {duration_seconds} seconds...")
         
@@ -607,14 +611,14 @@ class SpeechToTextEngine:
         # Return combined results
         return " ".join(transcription_results)
 
-    def get_live_voice_input_blocking(self, duration_seconds=30, use_chunked=True):
+    def get_live_voice_input_blocking(self, duration_seconds=30, use_chunked=True, require_hotword=True):
         """Synchronous wrapper around ``get_live_voice_input``.
 
         This allows the live transcription workflow to be executed from a
         background thread using ``run_in_executor`` without blocking the main
         asyncio event loop.
         """
-        return asyncio.run(self.get_live_voice_input(duration_seconds, use_chunked))
+        return asyncio.run(self.get_live_voice_input(duration_seconds, use_chunked, require_hotword=require_hotword))
 
     def get_voice_input(self):
         """


### PR DESCRIPTION
## Summary
- allow `get_live_voice_input` to skip hotword detection
- expose new flag through `get_live_voice_input_blocking`
- pause hotword listener when the assistant speaks
- listen for 10 seconds of follow‑up speech before resuming hotword mode

## Testing
- `python -m py_compile Wheatly/python/src/main.py Wheatly/python/src/stt/stt_engine.py Wheatly/python/src/tts/tts_engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684295c7408c8330af8df55862cf2925