### PR TITLE
Fix STT silence handling and resume

### DIFF
--- a/Wheatly/python/src/config/config.example.yaml
+++ b/Wheatly/python/src/config/config.example.yaml
@@ -15,7 +15,7 @@ stt:
   channels: 1
   rate: 44100
   threshold: 3000
-  silence_limit: 1
+  silence_limit: 2
 
 tts:
   enabled: false

--- a/Wheatly/python/src/main.py
+++ b/Wheatly/python/src/main.py
@@ -292,8 +292,10 @@ async def async_conversation_loop(manager, gpt_client, stt_engine, tts_engine, a
 
                 tts_engine.generate_and_play_advanced(gpt_text)
 
-                if stt_enabled and last_input_type == "voice":
+                if stt_enabled:
                     stt_engine.resume_listening()
+
+                if stt_enabled and last_input_type == "voice":
                     print("[STT] Listening for follow-up without hotword for 10 seconds...")
                     loop = asyncio.get_event_loop()
                     follow_up = await loop.run_in_executor(

--- a/Wheatly/python/src/stt/stt_engine.py
+++ b/Wheatly/python/src/stt/stt_engine.py
@@ -35,7 +35,7 @@ class SpeechToTextEngine:
         self.CHANNELS = stt_config.get("channels", 1)
         self.RATE = stt_config.get("rate", 16000)  # 16kHz is optimal for Whisper
         self.THRESHOLD = stt_config.get("threshold", 3000)
-        self.SILENCE_LIMIT = stt_config.get("silence_limit", 1)
+        self.SILENCE_LIMIT = stt_config.get("silence_limit", 2)
         self._audio = None
         self._stream = None
         self._porcupine = None
@@ -653,13 +653,16 @@ class SpeechToTextEngine:
         return " ".join(transcription_results)
 
     def get_live_voice_input_blocking(self, duration_seconds=30, use_chunked=True, require_hotword=True):
-        """Synchronous wrapper around ``get_live_voice_input``.
+        """Record and transcribe speech until silence is detected."""
 
-        This allows the live transcription workflow to be executed from a
-        background thread using ``run_in_executor`` without blocking the main
-        asyncio event loop.
-        """
-        return asyncio.run(self.get_live_voice_input(duration_seconds, use_chunked, require_hotword=require_hotword))
+        if require_hotword:
+            idx = self.listen_for_hotword()
+            if idx is None:
+                return ""
+        else:
+            print("[STT] Listening for speech...")
+
+        return self.record_and_transcribe()
 
     def get_voice_input(self):
         """


### PR DESCRIPTION
## Summary
- default STT silence timeout to 2 seconds
- ensure STT resumes after TTS regardless of input type
- simplify live voice input to stop after silence
- update example config

## Testing
- `pytest -q`
- `python Wheatly/python/src/test.py` *(fails: ModuleNotFoundError: No module named 'pyaudio')*

------
https://chatgpt.com/codex/tasks/task_e_68429ecc53208330b2d031aab199e061