### PR TITLE
Improve silence handling

### DIFF
--- a/Wheatly/python/src/config/config.example.yaml
+++ b/Wheatly/python/src/config/config.example.yaml
@@ -14,8 +14,8 @@ stt:
   chunk: 1024
   channels: 1
   rate: 44100
-  threshold: 1500
-  silence_limit: 2
+  threshold: 1000
+  silence_limit: 3
 
 tts:
   enabled: false

--- a/Wheatly/python/src/main.py
+++ b/Wheatly/python/src/main.py
@@ -37,8 +37,8 @@ CHUNK = 1024  # Audio chunk size
 FORMAT = pyaudio.paInt16  # Audio format
 CHANNELS = 1  # Mono audio
 RATE = 44100  # Audio sample rate
-THRESHOLD = 3000  # Audio threshold for silence detection
-SILENCE_LIMIT = 1  # Silence limit in seconds
+THRESHOLD = 1000  # Audio threshold for silence detection (legacy)
+SILENCE_LIMIT = 3  # Silence limit in seconds (legacy)
 
 # Initialize colorama for colored terminal output
 init(autoreset=True)


### PR DESCRIPTION
## Summary
- tune STT config defaults
- lower legacy constants in `main.py`
- allow `record_until_silent` to timeout when no audio is detected
- propagate timeout to blocking voice input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a87f36a883309cffbf945783759d