### PR TITLE
Enable realtime transcription after hotword

### DIFF
--- a/Wheatly/python/src/main.py
+++ b/Wheatly/python/src/main.py
@@ -198,9 +198,12 @@ async def hotword_listener(queue, stt_engine):
             if stt_engine.is_paused():
                 await asyncio.sleep(0.1)
                 continue
-            # Run the blocking live voice input workflow in a thread
+            # Run the live transcription workflow in a thread to avoid blocking
             text = await loop.run_in_executor(
-                None, stt_engine.get_live_voice_input_blocking
+                None,
+                lambda: stt_engine.get_live_voice_input_blocking(
+                    30, False, True
+                ),
             )
             if text and text.strip():
                 await queue.put(
@@ -328,7 +331,7 @@ async def async_conversation_loop(
                     loop = asyncio.get_event_loop()
                     follow_up_future = loop.run_in_executor(
                         None,
-                        lambda: stt_engine.get_live_voice_input_blocking(10, True, False)
+                        lambda: stt_engine.get_live_voice_input_blocking(10, False, False)
                     )
                     queue_get_task = asyncio.create_task(queue.get())
                     done, _ = await asyncio.wait(


### PR DESCRIPTION
## Summary
- switch STT engine to use OpenAI realtime transcription sessions
- stream delta events for partial transcripts
- run realtime transcription after hotword detection
- log when realtime sessions start and stop

## Testing
- `python -m py_compile Wheatly/python/src/stt/stt_engine.py Wheatly/python/src/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842cb885de48330b9b539515499c15d