### PR TITLE
Fix realtime STT configuration

### DIFF
--- a/Wheatly/python/src/stt/stt_engine.py
+++ b/Wheatly/python/src/stt/stt_engine.py
@@ -112,9 +112,13 @@ class SpeechToTextEngine:
             session_config = {
                 "type": "transcription_session.update",
                 "input_audio_format": "pcm16",
-                "input_audio_transcription": {
-                    "model": "gpt-4o-transcribe",
-                },
+                # `input_audio_transcription` must be a list of objects
+                # describing the transcription configuration
+                "input_audio_transcription": [
+                    {
+                        "model": "gpt-4o-transcribe",
+                    }
+                ],
                 "turn_detection": {
                     "type": "server_vad",
                     "threshold": 0.5,


### PR DESCRIPTION
## Summary
- ensure realtime transcription session uses list format for input_audio_transcription

## Testing
- `python -m py_compile Wheatly/python/src/stt/stt_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_6842cfe9f79883308195ca0084a5e957