### PR TITLE
Simplify STT and centralise hotword loop

### DIFF
--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -6,7 +6,7 @@ This document explains the main components that power the Wheatley assistant and
 
 1. **Speech to Text (STT)**
    - Implemented in `stt/stt_engine.py`.
-   - Uses Porcupine for hotword detection and captures live microphone input.
+   - Uses Porcupine for hotword detection, then records speech until silence and transcribes the result with Whisper.
 2. **Conversation Manager**
    - Located in `assistant/assistant.py`.
    - Keeps a bounded history of system and user messages for context.

--- a/docs/tts_and_hotword_flow.md
+++ b/docs/tts_and_hotword_flow.md
@@ -14,5 +14,7 @@ The use of `NamedTemporaryFile` keeps file operations minimal and avoids leaving
 2. **Detection** – Each audio frame is analysed for configured keywords. When a keyword is detected the function returns its index.
 3. **Integration** – Higher level workflows pause listening during TTS playback and resume afterwards so that hotword detection is responsive.
 
+Once a hotword is detected, the engine records speech until a short period of silence is reached and then submits the audio to OpenAI Whisper for transcription.
+
 The engine exposes `pause_listening()` and `resume_listening()` helpers which are used by `main.py` when playing back responses.
 


### PR DESCRIPTION
## Summary
- move hotword listener logic inside the STT engine
- adapt main loop to consume STT events
- document record-and-transcribe flow

## Testing
- `python -m py_compile Wheatly/python/src/main.py Wheatly/python/src/stt/stt_engine.py`
- `python Wheatly/python/src/test.py` *(fails: NameError inside elevenlabs)*

------
https://chatgpt.com/codex/tasks/task_e_6842d2bf0de083308e3dcd29c8f24786