### PR TITLE
Add mic LED command

### DIFF
--- a/Wheatly/ino/M5 stack Core2/M5Stack_Core2.ino
+++ b/Wheatly/ino/M5 stack Core2/M5Stack_Core2.ino
@@ -22,6 +22,9 @@ constexpr uint32_t LINK_BAUD = 115200;  // must match OpenRB
 #define NUM_LEDS 8
 Adafruit_NeoPixel leds(NUM_LEDS, LED_PIN, NEO_GRB + NEO_KHZ800);
 
+// LED index used to display microphone status
+constexpr int MIC_LED_INDEX = 17;
+
 /* ──────────────────────────────────────────────────────────────────────────
  *  VARIABLE & CONSTANT REFERENCE
  *  (reflects only how the sketch itself uses each symbol)
@@ -331,6 +334,25 @@ void loop()
       for (int i=0;i<NUM_LEDS;++i) leds.setPixelColor(i,col);
       leds.show();
       Serial.printf("[LED] Set R=%d G=%d B=%d\n", r,g,b);
+    }
+
+    /* --- mic status LED --- */
+    else if (cmd.startsWith("SET_MIC_LED;")) {
+      int idx = MIC_LED_INDEX;
+      int r=0,g=0,b=0;
+      int iI=cmd.indexOf("IDX="), rI=cmd.indexOf("R="), gI=cmd.indexOf("G="), bI=cmd.indexOf("B=");
+      if (iI>=0) idx = cmd.substring(iI+4, cmd.indexOf(';', iI+4)).toInt();
+      if (rI>=0) r = cmd.substring(rI+2, cmd.indexOf(';', rI+2)).toInt();
+      if (gI>=0) g = cmd.substring(gI+2, cmd.indexOf(';', gI+2)).toInt();
+      if (bI>=0) {
+        int e = cmd.indexOf(';', bI+2); if (e==-1) e=cmd.length();
+        b = cmd.substring(bI+2, e).toInt();
+      }
+      if (idx >= 0 && idx < NUM_LEDS) {
+        leds.setPixelColor(idx, leds.Color(r,g,b));
+        leds.show();
+      }
+      Serial.printf("[MIC_LED] IDX=%d R=%d G=%d B=%d\n", idx, r, g, b);
     }
 
     /* --- SET_SERVO_CONFIG --- */

--- a/Wheatly/python/src/hardware/arduino_interface.py
+++ b/Wheatly/python/src/hardware/arduino_interface.py
@@ -1,5 +1,8 @@
 # Arduino interface for communicating with Arduino hardware
 
+# Index of the NeoPixel used for microphone status indication
+MIC_LED_INDEX = 17
+
 class ArduinoInterface:
     def __init__(self, port, baud_rate=115200, dry_run=False):
         self.port = port
@@ -120,6 +123,18 @@ class ArduinoInterface:
         else:
             print("Arduino not connected. Cannot send command.")
         return response
+
+    def set_led_color(self, r: int, g: int, b: int):
+        """Set the NeoPixel LED color on the Arduino."""
+        led_command = f"SET_LED;R={int(r)};G={int(g)};B={int(b)}\n"
+        self.send_command(led_command)
+
+    def set_mic_led_color(self, r: int, g: int, b: int, idx: int = MIC_LED_INDEX):
+        """Set only the microphone status NeoPixel to the given color."""
+        led_command = (
+            f"SET_MIC_LED;IDX={int(idx)};R={int(r)};G={int(g)};B={int(b)}\n"
+        )
+        self.send_command(led_command)
 
     def read_response(self):
         """Read a response from the Arduino."""

--- a/Wheatly/python/src/main.py
+++ b/Wheatly/python/src/main.py
@@ -136,11 +136,14 @@ def initialize_assistant(config):
         try:
             arduino_interface = ArduinoInterface(port=port)
             arduino_interface.connect()
+            stt_engine.arduino_interface = arduino_interface
         except Exception as e:
             print(f"Could not connect to Arduino on {port}: {e}. Running in dry run mode.")
             arduino_interface = ArduinoInterface(port=port, dry_run=True)
+            stt_engine.arduino_interface = arduino_interface
     else:
         arduino_interface = ArduinoInterface(port="dryrun", dry_run=True)
+        stt_engine.arduino_interface = arduino_interface
     elapsed = time.time() - start_time
     logging.info(f"initialize_assistant completed in {elapsed:.3f} seconds.")
     # Return all initialized components and feature flags

--- a/Wheatly/python/src/puppet.py
+++ b/Wheatly/python/src/puppet.py
@@ -30,6 +30,9 @@ DOT_COLOR   = "#ff4040"
 PX          = 6
 BAR_HEIGHT  = 28
 
+# Index of the NeoPixel used for microphone status indication
+MIC_LED_INDEX = 17
+
 COL_NAME, COL_SCALE, COL_VEL, COL_VEL_LBL, COL_IDLE,\
 COL_IDLE_LBL, COL_INTV, COL_INTV_LBL, COL_MOVE, COL_CFG = range(10)
 
@@ -300,6 +303,8 @@ class PuppetGUI(Tk):
                    ).pack(side="left", padx=(10, 6))
         ttk.Button(fr, text="Send LED", command=self._send_led
                    ).pack(side="left")
+        ttk.Button(fr, text="Send Mic LED", command=self._send_mic_led
+                   ).pack(side="left", padx=(6, 0))
 
     def _rgb(self, parent, default):
         e = ttk.Entry(parent, width=5, justify="center")
@@ -475,6 +480,16 @@ class PuppetGUI(Tk):
             return self._msg("bad LED")
         self.backend.send(
             f"SET_LED;R={max(0,min(255,r))};G={max(0,min(255,g))};"
+            f"B={max(0,min(255,b))};")
+
+    def _send_mic_led(self):
+        try:
+            r, g, b = map(int, (self.r.get(), self.g.get(), self.b.get()))
+        except ValueError:
+            return self._msg("bad LED")
+        self.backend.send(
+            f"SET_MIC_LED;IDX={MIC_LED_INDEX};"
+            f"R={max(0,min(255,r))};G={max(0,min(255,g))};"
             f"B={max(0,min(255,b))};")
 
     # utilities ---------------------------------------------------------


### PR DESCRIPTION
## Summary
- add mic LED index constant to Puppet GUI
- enable Puppet GUI to send `SET_MIC_LED` commands

## Testing
- `python -m py_compile Wheatly/python/src/puppet.py`
- `python Wheatly/python/src/test.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6847cf51b33c8330b3e24af9a3ea5f14