### PR TITLE
Improve documentation visuals

### DIFF
--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -1,44 +1,83 @@
 # Project Architecture Overview
 
-This document explains the main components that power the Wheatley assistant and how they work together.
+This document provides a detailed look at how the Wheatley assistant is structured. The goal is to give a clear picture of the moving parts and how they communicate with each other.
 
 ## High-Level Components
 
 1. **Speech to Text (STT)**
    - Implemented in `stt/stt_engine.py`.
-   - Uses Porcupine for hotword detection, then records speech until silence and transcribes the result with Whisper.
+   - Uses Porcupine for hotword detection and OpenAI Whisper to transcribe speech once detected.
+   - Exposes helper methods for pausing and resuming listening so TTS playback does not interfere with the microphone.
 2. **Conversation Manager**
    - Located in `assistant/assistant.py`.
-   - Keeps a bounded history of system and user messages for context.
+   - Maintains a bounded history buffer and continually refreshes the system prompt with the current time and day.
 3. **Large Language Model (LLM)**
    - Accessed through `llm/llm_client.py`.
-   - Handles calls to the OpenAI API and provides workflow utilities.
+   - Wraps OpenAI's chat API and provides tooling for workflow execution, such as calendar or Spotify integration.
 4. **Text to Speech (TTS)**
    - Provided by `tts/tts_engine.py`.
-   - Converts assistant responses into audio using the ElevenLabs API.
+   - Converts assistant responses into audio using the ElevenLabs API and streams playback to the user.
 5. **Hardware Interface**
    - Managed by `hardware/arduino_interface.py`.
-   - Controls servos and LED animations on the connected Arduino board.
+   - Sends servo and LED commands to an Arduino-based controller for expressive animations.
+
+## Component Diagram
+
+```mermaid
+graph TD
+    A[User Input] -->|speech| B(STT Engine)
+    B --> C{LLM Request}
+    C -->|chat| D(LLM Client)
+    D --> E(Conversation Manager)
+    E --> F(TTS Engine)
+    F -->|audio| G[Speakers]
+    D --> H(Arduino Interface)
+    H --> I[Servos / LEDs]
+```
+
+The diagram illustrates how user input flows through the STT engine into the LLM client. Responses are spoken via the TTS engine and can trigger hardware animations.
 
 ## Execution Flow
 
-`main.py` ties all components together. When started it:
+`main.py` acts as the conductor:
 
-1. Loads configuration from `config/config.yaml`.
-2. Initialises STT, TTS, the LLM client and the Arduino interface.
-3. Prints an ASCII welcome banner and an initial greeting from the assistant.
-4. Enters an asynchronous loop that:
-   - Waits for user input via text or the hotword listener.
-   - Sends the conversation to the LLM for processing and tool calls.
-   - Executes any returned workflow functions.
-   - Plays the assistant response and triggers an animation.
+1. **Initialisation** – Reads `config/config.yaml` and creates instances of STT, TTS, the LLM client and the Arduino interface.
+2. **Welcome** – Prints an ASCII banner and sends a greeting through the TTS engine.
+3. **Conversation Loop** – Repeatedly:
+   - Waits for either text input or the configured hotword.
+   - Sends the collected conversation history to the LLM.
+   - Executes any tool calls (for example, to read the calendar or control music).
+   - Streams the assistant's reply through the TTS engine and triggers a matching animation via the Arduino.
+4. **Shutdown** – Cleans up resources when the user types or says `exit`.
 
-The loop continues until the user types or says "exit", after which resources are cleaned up and the program terminates.
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant STT as STT Engine
+    participant M as Conversation Manager
+    participant L as LLM Client
+    participant T as TTS Engine
+    participant H as Hardware
+
+    U->>STT: speak after hotword
+    STT->>M: transcribed text
+    M->>L: conversation history
+    L->>M: assistant response
+    M->>T: text for playback
+    T->>H: notify start
+    T->>U: audio output
+    H-->>U: servo and LED feedback
+```
 
 ## Additional Utilities
 
 - `install_prerequisites.py` installs packages listed in `requirements.txt`.
-- `docs/tts_and_hotword_flow.md` details how speech synthesis and hotword detection operate.
-- `old_inspiration.py` contains prototype code kept for reference.
+- `docs/tts_and_hotword_flow.md` describes speech synthesis and hotword detection in depth.
+- `old_inspiration.py` is prototype code kept for reference.
+- `docs/component_communication.md` maps how each Python module talks to the others.
+- `docs/detailed_event_flow.md` walks through the full event loop step by step.
 
-This structure keeps the codebase modular so that each part of the assistant can be developed or replaced independently.
+This modular architecture makes it easy to swap out individual components. For example, you could replace the STT engine with another speech recogniser or use a different TTS provider without touching the rest of the system.
+

--- a/docs/component_communication.md
+++ b/docs/component_communication.md
@@ -1,0 +1,73 @@
+# Component Communication Details
+
+This document provides an exhaustive look at how the Python modules interact during a normal run of the Wheatley assistant. The goal is to map every significant message passing between scripts.
+
+## Overview
+
+All communication is orchestrated by `main.py`, which spawns asynchronous tasks and hands off work to various subsystems. The assistant is built around a queue-based event loop. Events originate from the user, timers, or hardware callbacks and are processed in order.
+
+## Key Scripts and Interactions
+
+1. **`main.py`**
+   - Bootstraps the assistant and creates the event queue.
+   - Dispatches user input and hotword events to the `ConversationManager`.
+   - Triggers tool workflows via `GPTClient` and delivers text to `TextToSpeechEngine`.
+   - Sends animation commands to `ArduinoInterface`.
+2. **`assistant/assistant.py`**
+   - Maintains conversation state and appends messages from all sources.
+   - Provides helpers for printing and trimming memory.
+3. **`llm/llm_client.py`**
+   - Calls the OpenAI API and decides when external tools should run.
+   - Returns both natural language replies and animation cues.
+4. **`stt/stt_engine.py`**
+   - Continuously listens for a hotword in a background task.
+   - After a hotword, records audio and submits it to Whisper for transcription.
+   - Pauses itself whenever the TTS engine is speaking to prevent feedback.
+5. **`tts/tts_engine.py`**
+   - Streams audio from ElevenLabs and notifies `ArduinoInterface` when playback starts and ends.
+6. **`hardware/arduino_interface.py`**
+   - Sends serial messages to the robot head controller.
+   - Provides servo position feedback used for debugging.
+
+The figure below summarises these connections.
+
+```mermaid
+flowchart LR
+    subgraph User Facing
+        U[User]
+        SP[Speakers]
+        MIC[Microphone]
+    end
+    subgraph Core
+        MAIN[main.py]
+        CM[ConversationManager]
+        LLM[GPTClient]
+        TTS[TextToSpeechEngine]
+        STT[SpeechToTextEngine]
+        HW[ArduinoInterface]
+    end
+    U --speak--> MIC
+    MIC --audio--> STT
+    STT --text--> MAIN
+    MAIN --update--> CM
+    CM --prompt--> LLM
+    LLM --reply--> CM
+    CM --message--> MAIN
+    MAIN --say--> TTS
+    TTS --status--> STT
+    TTS --audio--> SP
+    MAIN --animate--> HW
+    HW --feedback--> MAIN
+```
+
+## Message Ordering
+
+The queue in `main.py` ensures that voice input, text commands, timers, and hardware callbacks are processed sequentially. Each component emits events with a source tag so the manager can store them appropriately.
+
+- **Voice Input** – produced by `SpeechToTextEngine` as soon as transcription completes.
+- **Text Commands** – read from the terminal by the `user_input_producer` task.
+- **Tool Results** – returned by `Functions.execute_workflow` and injected into the conversation as system messages.
+- **Hardware Events** – such as servo errors, forwarded from `ArduinoInterface`.
+
+Understanding this flow helps when adding new integrations. New sources simply place events onto the queue and existing logic remains unchanged.
+

--- a/docs/detailed_event_flow.md
+++ b/docs/detailed_event_flow.md
@@ -1,0 +1,56 @@
+# Detailed Event Flow
+
+The Wheatley assistant relies on an asynchronous event loop. This document explains how events are created, processed, and how each subsystem cooperates. The visualization is deliberately verbose so new contributors can trace every step of execution.
+
+## Life of an Event
+
+1. **User or External Trigger**
+   - Terminal input, hotword transcription, timers, or hardware feedback create an event object.
+2. **Queue Insertion**
+   - All events are placed onto a central `asyncio.Queue` in `main.py`.
+3. **Retrieval**
+   - The `async_conversation_loop` waits on the queue and pulls events one at a time.
+4. **Processing**
+   - `process_event` appends the event to `ConversationManager` and checks for an exit condition.
+5. **LLM Interaction**
+   - `GPTClient` uses the latest conversation to produce a response and optional tool workflow.
+6. **Tool Workflow**
+   - Tools run via `Functions.execute_workflow`, pushing further events like timer expirations.
+7. **TTS & Hardware**
+   - The response text is spoken by `TextToSpeechEngine`. Hardware animations are triggered in parallel.
+8. **Follow-up Listening**
+   - If enabled, `SpeechToTextEngine` listens without a hotword for a short time to capture follow-up commands.
+
+## Comprehensive Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User
+    participant MIC as Microphone
+    participant STT as STT Engine
+    participant Q as Event Queue
+    participant LOOP as async_conversation_loop
+    participant CM as ConversationManager
+    participant LLM as GPTClient
+    participant TTS as TTS Engine
+    participant HW as ArduinoInterface
+
+    U->>MIC: speak
+    MIC->>STT: audio frames
+    STT->>Q: Event(text)
+    LOOP->>Q: await event
+    Q-->>LOOP: Event(text)
+    LOOP->>CM: update history
+    LOOP->>LLM: current conversation
+    LLM-->>LOOP: reply & workflow
+    LOOP->>CM: store assistant text
+    LOOP->>TTS: speak reply
+    TTS->>HW: start animation
+    TTS->>U: audio
+    HW-->>U: movement & LEDs
+    LOOP->>STT: optional follow-up listening
+```
+
+Events from timers or external integrations follow the exact same path. The queue acts as the glue that allows independent producers and consumers to operate without blocking each other.
+


### PR DESCRIPTION
## Summary
- expand architecture overview with diagrams and deeper explanations
- elaborate on text-to-speech and hotword flow and include mermaid diagrams
- add detailed docs on component communication and the event loop

## Testing
- `python Wheatly/python/src/test.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684831ec7788833098afd5b5c74203c1