### PR TITLE
Add hardware command docs

### DIFF
--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -20,6 +20,7 @@ This document provides a detailed look at how the Wheatley assistant is structur
 5. **Hardware Interface**
    - Managed by `hardware/arduino_interface.py`.
    - Sends servo and LED commands to an Arduino-based controller for expressive animations.
+   - The exact serial commands exchanged with the M5Stack Core2 and the OpenRB‑150 are described in [hardware_command_flow.md](hardware_command_flow.md).
 
 ## Component Diagram
 

--- a/docs/component_communication.md
+++ b/docs/component_communication.md
@@ -2,6 +2,8 @@
 
 This document provides an exhaustive look at how the Python modules interact during a normal run of the Wheatley assistant. The goal is to map every significant message passing between scripts.
 
+For a detailed breakdown of the serial protocol used to talk to the M5Stack Core2 and the OpenRB‑150, see [hardware_command_flow.md](hardware_command_flow.md). Keeping the hardware commands separate helps this document stay focused on the software layer.
+
 ## Overview
 
 All communication is orchestrated by `main.py`, which spawns asynchronous tasks and hands off work to various subsystems. The assistant is built around a queue-based event loop. Events originate from the user, timers, or hardware callbacks and are processed in order.

--- a/docs/hardware_command_flow.md
+++ b/docs/hardware_command_flow.md
@@ -1,0 +1,73 @@
+# Hardware Command Flow
+
+This document covers the messages exchanged between the Python code, the M5Stack Core2, the OpenRB‑150 board and the RGB LEDs.  It focuses purely on the serial commands so other documents can concentrate on software or event flow.
+
+## Overview
+
+Three devices cooperate:
+
+1. **Python application** – runs on the host computer and sends commands over USB.
+2. **M5Stack Core2** – acts as a bridge and user interface.  It receives USB commands, drives the LED strip and forwards servo instructions to the OpenRB‑150 via UART2.
+3. **OpenRB‑150** – controls the Dynamixel servos and reports calibration data back to the Core2.
+
+The diagram below shows the direction of each message type.
+
+```mermaid
+sequenceDiagram
+    participant P as Python
+    participant C as Core2
+    participant R as OpenRB-150
+    participant L as RGB LEDs
+
+    P->>C: SET_LED / SET_MIC_LED / SET_SERVO_CONFIG
+    C->>L: update LED colours
+    C->>R: MOVE_SERVO commands
+    R-->>C: servo limits (CSV)
+    C-->>P: SERVO_CONFIG:...
+    R->>C: HELLO
+    C->>R: ESP32 (handshake reply)
+```
+
+## Command Reference
+
+### LED Control
+- `SET_LED;R=<r>;G=<g>;B=<b>` – sets all LEDs to the specified colour.
+- `SET_MIC_LED;IDX=<i>;R=<r>;G=<g>;B=<b>` – changes the LED used as microphone indicator.
+
+Both commands are sent from Python to the Core2.  The sketch immediately updates the NeoPixel strip and echoes a short confirmation message over USB.
+
+### Servo Configuration
+- `SET_SERVO_CONFIG:<id>,<target>,<vel>,<idle>,<interval>;...` – updates servo angles and animation parameters in bulk.
+- `GET_SERVO_CONFIG` – request the latest calibration table from the Core2.
+- `SERVO_CONFIG:<id>,<min>,<max>,<ping>;...` – response emitted by the Core2 after calibration or when requested.
+
+Python issues `GET_SERVO_CONFIG` during start‑up and whenever calibration data is needed.  The Core2 forwards the information received from the OpenRB‑150.  Individual servo move commands are generated when animations run:
+
+- `MOVE_SERVO;ID=<id>;TARGET=<deg>;VELOCITY=<deg/s>` – forwarded by the Core2 to the OpenRB‑150 which then drives the Dynamixel bus.
+
+### Handshake
+During boot the OpenRB‑150 repeatedly sends `HELLO` over the UART link.  The Core2 replies with `ESP32`.  If the Core2 does not respond within ten seconds the OpenRB‑150 enters a dry‑run mode and skips calibration.
+
+```mermaid
+sequenceDiagram
+    participant R as OpenRB-150
+    participant C as Core2
+
+    loop until timeout
+        R->>C: HELLO
+        alt reply received
+            C->>R: ESP32
+            R->>R: normal operation
+            break
+        end
+    end
+    alt timeout
+        R->>R: dry-run mode
+    end
+```
+
+## Related Documentation
+- [architecture_overview.md](architecture_overview.md) – big-picture structure of the application.
+- [component_communication.md](component_communication.md) – how Python modules pass events around.
+- [detailed_event_flow.md](detailed_event_flow.md) – a step-by-step walk through of the async loop.
+


### PR DESCRIPTION
## Summary
- document serial commands between Python, Core2 and OpenRB-150
- link other docs to the new command reference

## Testing
- `pytest -q`
- `python Wheatly/python/src/test.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684836bab92883308bb563d5aa639472