### PR TITLE
Improve TTS startup by keeping speakers active

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Maintain a “Documented Features” section in this file. Update whenever you a
 - [user-authentication](docs/user-authentication.md)
 - [data-exporter](docs/data-exporter.md)
 - [timing-logging](docs/timing-logging.md)
-- … add your new feature here …
+- [speaker-warmup](docs/speaker-warmup.md)
 ```
 
 ---

--- a/docs/speaker-warmup.md
+++ b/docs/speaker-warmup.md
@@ -1,0 +1,23 @@
+# Speaker Warmup
+
+## Purpose
+Keep the speakers and audio driver active so text-to-speech playback starts immediately.
+
+## Usage
+The feature is automatically enabled when `TextToSpeechEngine` is instantiated. A background thread
+plays a barely audible tone every half second to prevent the audio device from sleeping. Call
+`close()` on the engine to release the hardware when shutting down.
+
+## Internals
+- The engine opens a persistent PyAudio stream at 22.05 kHz mono.
+- `_keep_audio_device_alive` runs in a daemon thread, writing a -50 dB 60 Hz tone whenever
+  TTS is idle.
+- During playback `generate_and_play_advanced` sets a flag so the keep-alive tone pauses.
+
+## Examples
+```python
+from tts.tts_engine import TextToSpeechEngine
+engine = TextToSpeechEngine()
+engine.generate_and_play_advanced("Ready to speak with no delay")
+engine.close()
+```


### PR DESCRIPTION
## Summary
- keep a persistent PyAudio stream and play a quiet tone in the background
- add a `close()` method and keep-alive thread in the TTS engine
- document the new speaker warmup behaviour
- list `speaker-warmup` in documented features

## Testing
- `python test.py` *(fails: ModuleNotFoundError: No module named 'playsound')*

------
https://chatgpt.com/codex/tasks/task_e_684a6cc634148330859103502276728b