### PR TITLE
Add timeline presenter and reset timings each run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Maintain a “Documented Features” section in this file. Update whenever you a
 - [data-exporter](docs/data-exporter.md)
 - [timing-logging](docs/timing-logging.md)
 - [speaker-warmup](docs/speaker-warmup.md)
+- [present-timeline](docs/present-timeline.md)
 ```
 
 ---

--- a/Wheatly/python/src/main.py
+++ b/Wheatly/python/src/main.py
@@ -37,7 +37,7 @@ from assistant.assistant import ConversationManager  # Manages conversation hist
 from llm.llm_client import GPTClient, Functions  # LLM client and function tools
 from tts.tts_engine import TextToSpeechEngine  # Text-to-speech engine
 from stt.stt_engine import SpeechToTextEngine  # Speech-to-text engine
-from utils.timing_logger import record_timing, export_timings
+from utils.timing_logger import record_timing, export_timings, clear_timings
 
 
 # Initialize colorama for colored terminal output
@@ -451,6 +451,9 @@ def main():
         help="Write timing information to timings.json on exit",
     )
     args = parser.parse_args()
+
+    # Start each run with a clean timing log
+    clear_timings()
 
     if args.export_timings:
         atexit.register(export_timings)

--- a/Wheatly/python/src/present_timeline.py
+++ b/Wheatly/python/src/present_timeline.py
@@ -1,0 +1,48 @@
+"""Utility to display a chronological timeline from timing and log files."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import datetime as dt
+from typing import List, Dict
+
+
+def load_timings(path: str = "timings.json") -> List[Dict[str, str]]:
+    """Load timing entries from ``path`` if it exists."""
+    if not os.path.exists(path):
+        return []
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_logs(path: str = "assistant.log") -> List[Dict[str, str]]:
+    """Parse ``assistant.log`` into timestamped entries."""
+    events = []
+    if not os.path.exists(path):
+        return events
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            match = re.match(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\s+([A-Z]+):\s+(.*)$", line)
+            if match:
+                ts_str, level, message = match.groups()
+                ts = dt.datetime.fromisoformat(ts_str)
+                events.append({"timestamp": ts, "description": f"LOG {level}: {message.strip()}"})
+    return events
+
+
+def present_timeline(timing_file: str = "timings.json", log_file: str = "assistant.log") -> None:
+    """Print combined timing and log events sorted by time."""
+    events: List[Dict[str, str]] = []
+    for t in load_timings(timing_file):
+        ts = dt.datetime.fromisoformat(t["startTime"])
+        events.append({"timestamp": ts, "description": f"{t['functionality']} took {t['durationMs']}ms"})
+    events.extend(load_logs(log_file))
+    events.sort(key=lambda e: e["timestamp"])
+    for event in events:
+        print(f"{event['timestamp'].isoformat()} - {event['description']}")
+
+
+if __name__ == "__main__":
+    present_timeline()

--- a/Wheatly/python/src/utils/timing_logger.py
+++ b/Wheatly/python/src/utils/timing_logger.py
@@ -5,11 +5,28 @@ from __future__ import annotations
 import time
 import datetime as _dt
 import json
+import os
 from typing import List, Dict, Any
 
 # Central in-memory store for timing entries
 
 timings: List[Dict[str, Any]] = []
+
+
+def clear_timings(path: str = "timings.json") -> None:
+    """Reset stored timings and remove the timing file if present.
+
+    Parameters
+    ----------
+    path:
+        Location of the timings JSON file to delete.
+    """
+    timings.clear()
+    if os.path.exists(path):
+        try:
+            os.remove(path)
+        except OSError as e:
+            print(f"Failed to remove {path}: {e}")
 
 
 def record_timing(name: str, start: float) -> None:

--- a/docs/present-timeline.md
+++ b/docs/present-timeline.md
@@ -1,0 +1,25 @@
+# Present Timeline
+
+## Purpose
+Provide a simple CLI command to view a chronological list of events after the assistant finishes running.
+
+## Usage
+- Run the assistant with timing export enabled (default behaviour).
+- After shutdown execute:
+  ```bash
+  python present_timeline.py
+  ```
+  The script reads `timings.json` and `assistant.log` and prints a sorted timeline.
+
+## Internals
+- `load_timings()` parses `timings.json`.
+- `load_logs()` parses `assistant.log` entries.
+- `present_timeline()` merges both sources and orders them by timestamp.
+
+## Examples
+```bash
+$ python present_timeline.py
+2025-06-11T17:41:10.559211 - initialize_assistant took 3189ms
+2025-06-11T17:41:10 INFO: some log message
+...
+```


### PR DESCRIPTION
## Summary
- add new `present_timeline.py` utility script and docs
- clear timings at startup via `clear_timings`
- document new feature in `AGENTS.md`

## Testing
- `python Wheatly/python/src/test.py` *(fails: ModuleNotFoundError: No module named 'playsound')*

------
https://chatgpt.com/codex/tasks/task_e_684a911b50fc8330a2b273976a1e6b3b