### PR TITLE
Improve long‑term memory usage

### DIFF
--- a/Wheatly/python/src/llm/llm_client.py
+++ b/Wheatly/python/src/llm/llm_client.py
@@ -277,7 +277,7 @@ class Functions:
             func_name = item.get("name")
             logging.info(f"\n--- Tool Execution: {func_name} ---")
             tool_start = time.time()
-            if self.tts_enabled:
+            if self.tts_enabled and func_name not in {"write_long_term_memory", "read_long_term_memory"}:
                 conversation = [
                     {"role": "system", "content": "Act as Weatly from portal 2. in 10 words summarize the function call as if you are doing what it says. always say numbers out in full. try to enterpet things yourself, so long and lat should be city names. try to be funny but also short. Do not give the result of the function, just explain what you are doing. for example: generating joke. or adding numbers"},
                     {"role": "user", "content": f"Executing function: {func_name} with arguments: {item.get('arguments')}"}

--- a/Wheatly/python/src/main.py
+++ b/Wheatly/python/src/main.py
@@ -269,6 +269,10 @@ def run_tool_workflow(manager: ConversationManager, gpt_client: GPTClient, queue
                         manager.add_text_to_conversation("system", f"Info: {context_text}")
             workflow = [item for item in workflow if item.get("name") != "web_search_call_result"]
 
+        # Always fetch memory before running tools
+        mem_result = Functions().read_long_term_memory()
+        manager.add_text_to_conversation("system", str(mem_result))
+
         if not workflow:
             return
 

--- a/docs/long-term-memory.md
+++ b/docs/long-term-memory.md
@@ -7,6 +7,8 @@ Provide persistent storage so Wheatley can recall facts between sessions.
 - The LLM invokes the `write_long_term_memory` tool with a JSON object under the `data` field.
 - Stored entries accumulate in `long_term_memory.json`.
 - `read_long_term_memory` returns the list of stored objects.
+- Memory access is silent; Wheatley no longer speaks when storing or retrieving data.
+- The assistant fetches long-term memory at the start of every tool workflow.
 
 ## Internals
 - `utils.long_term_memory` defines `append_memory` and `read_memory`.


### PR DESCRIPTION
## Summary
- disable TTS output when using long term memory tools
- auto-read memory before every workflow execution
- document new long term memory behaviour

## Testing
- `python -m pytest Wheatly/python/src/test.py` *(fails: ModuleNotFoundError for 'elevenlabs')*

------
https://chatgpt.com/codex/tasks/task_e_684c1297484c833096bfcbe1ae7cd072