### PR TITLE
Fix long term memory conversation update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,12 +39,16 @@ For each new feature or module, create a separate `*.md` under `docs/`:
 Maintain a “Documented Features” section in this file. Update whenever you add/remove a `docs/*.md`:
 ```markdown
 ## Documented Features
-- [user-authentication](docs/user-authentication.md)
-- [data-exporter](docs/data-exporter.md)
-- [timing-logging](docs/timing-logging.md)
-- [speaker-warmup](docs/speaker-warmup.md)
-- [present-timeline](docs/present-timeline.md)
+- [architecture_overview](docs/architecture_overview.md)
+- [Code_logic](docs/Code_logic.md)
+- [hardware_command_flow](docs/hardware_command_flow.md)
+- [LLM_logic](docs/LLM_logic.md)
 - [long-term-memory](docs/long-term-memory.md)
+- [present-timeline](docs/present-timeline.md)
+- [speaker-warmup](docs/speaker-warmup.md)
+- [timing-logging](docs/timing-logging.md)
+- [tts_and_hotword_flow](docs/tts_and_hotword_flow.md)
+- [Wiering_diagram](docs/Wiering_diagram.md)
 ```
 
 ---

--- a/Wheatly/python/src/assistant/assistant.py
+++ b/Wheatly/python/src/assistant/assistant.py
@@ -22,10 +22,13 @@ class ConversationManager:
         system_message = system_message.replace("<current_day>", current_day)
 
         self.max_memory = max_memory
-        self.messages = [{
-            "role": "system",
-            "content": system_message
-        }]
+        self.messages = [
+            {
+                "role": "system",
+                "content": system_message,
+            },
+            {"role": "system", "content": ""},  # placeholder for long term memory
+        ]
 
     def add_text_to_conversation(self, role, text):
         """Append ``text`` from ``role`` to the conversation history."""
@@ -42,9 +45,17 @@ class ConversationManager:
         self.messages[0]["content"] = system_message
 
         self.messages.append({"role": role, "content": text})
-        # Keep only the latest max_memory messages (excluding system)
-        while len(self.messages) > self.max_memory + 1:
-            self.messages.pop(1)
+        # Keep only the latest max_memory user/assistant turns
+        while len(self.messages) > self.max_memory + 2:
+            self.messages.pop(2)
+
+    def update_memory(self, memory_text: str) -> None:
+        """Set or replace the long term memory message."""
+
+        if len(self.messages) < 2:
+            self.messages.insert(1, {"role": "system", "content": memory_text})
+        else:
+            self.messages[1]["content"] = memory_text
 
     def get_conversation(self):
         """Return the current conversation as a list of message dicts."""

--- a/Wheatly/python/src/llm/llm_client.py
+++ b/Wheatly/python/src/llm/llm_client.py
@@ -277,7 +277,7 @@ class Functions:
             func_name = item.get("name")
             logging.info(f"\n--- Tool Execution: {func_name} ---")
             tool_start = time.time()
-            if self.tts_enabled and func_name not in {"write_long_term_memory", "read_long_term_memory"}:
+            if self.tts_enabled and func_name != "write_long_term_memory":
                 conversation = [
                     {"role": "system", "content": "Act as Weatly from portal 2. in 10 words summarize the function call as if you are doing what it says. always say numbers out in full. try to enterpet things yourself, so long and lat should be city names. try to be funny but also short. Do not give the result of the function, just explain what you are doing. for example: generating joke. or adding numbers"},
                     {"role": "user", "content": f"Executing function: {func_name} with arguments: {item.get('arguments')}"}
@@ -369,9 +369,6 @@ class Functions:
             elif func_name == "write_long_term_memory":
                 data = item.get("arguments", {}).get("data", {})
                 response = self.write_long_term_memory(data)
-                results.append((func_name, response))
-            elif func_name == "read_long_term_memory":
-                response = self.read_long_term_memory()
                 results.append((func_name, response))
 
             tool_elapsed = time.time() - tool_start

--- a/Wheatly/python/src/llm/llm_client_utils.py
+++ b/Wheatly/python/src/llm/llm_client_utils.py
@@ -267,17 +267,7 @@ def build_tools():
                 "additionalProperties": False
             }
         },
-        {
-            "type": "function",
-            "name": "read_long_term_memory",
-            "description": "Retrieve the JSON contents of Wheatley's long term memory store.",
-            "parameters": {
-                "type": "object",
-                "properties": {},
-                "required": [],
-                "additionalProperties": False
-            }
-        }
+        # Tool for persisting long term memory. Memory retrieval happens automatically.
     ]
     #print(tools)
     return tools

--- a/Wheatly/python/src/main.py
+++ b/Wheatly/python/src/main.py
@@ -269,9 +269,9 @@ def run_tool_workflow(manager: ConversationManager, gpt_client: GPTClient, queue
                         manager.add_text_to_conversation("system", f"Info: {context_text}")
             workflow = [item for item in workflow if item.get("name") != "web_search_call_result"]
 
-        # Always fetch memory before running tools
+        # Always fetch memory before running tools and update memory message
         mem_result = Functions().read_long_term_memory()
-        manager.add_text_to_conversation("system", str(mem_result))
+        manager.update_memory(str(mem_result))
 
         if not workflow:
             return

--- a/docs/long-term-memory.md
+++ b/docs/long-term-memory.md
@@ -6,13 +6,12 @@ Provide persistent storage so Wheatley can recall facts between sessions.
 ## Usage
 - The LLM invokes the `write_long_term_memory` tool with a JSON object under the `data` field.
 - Stored entries accumulate in `long_term_memory.json`.
-- `read_long_term_memory` returns the list of stored objects.
 - Memory access is silent; Wheatley no longer speaks when storing or retrieving data.
-- The assistant fetches long-term memory at the start of every tool workflow.
+- The assistant maintains a single memory message right after the system prompt and updates it every interaction.
 
 ## Internals
 - `utils.long_term_memory` defines `append_memory` and `read_memory`.
-- `Functions` exposes `write_long_term_memory` and `read_long_term_memory` to the LLM.
+- `Functions` exposes `write_long_term_memory` to the LLM.
 - Tool definitions live in `llm_client_utils.build_tools()`.
 
 ## Examples


### PR DESCRIPTION
## Summary
- ensure Documented Features list reflects all docs
- maintain persistent memory entry in conversation
- remove read_long_term_memory tool
- mention single memory update per transaction in long-term-memory docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python Wheatly/python/src/test.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684c176e76e88330a1f3a872793d6e7a