### PR TITLE
Enhance long term memory management

### DIFF
--- a/Wheatly/python/src/llm/llm_client.py
+++ b/Wheatly/python/src/llm/llm_client.py
@@ -370,6 +370,12 @@ class Functions:
                 data = item.get("arguments", {}).get("data", {})
                 response = self.write_long_term_memory(data)
                 results.append((func_name, response))
+            elif func_name == "edit_long_term_memory":
+                args = item.get("arguments", {})
+                index = args.get("index")
+                data = args.get("data", {})
+                response = self.edit_long_term_memory(index, data)
+                results.append((func_name, response))
 
             tool_elapsed = time.time() - tool_start
             logging.info(f"Tool '{func_name}' execution took {tool_elapsed:.3f} seconds.")
@@ -468,6 +474,12 @@ class Functions:
         """Return the contents of the long term memory file."""
         from utils.long_term_memory import read_memory
         return {"memory": read_memory(path=self.memory_path)}
+
+    def edit_long_term_memory(self, index: int, data: dict) -> str:
+        """Update the memory entry at ``index`` with ``data``."""
+        from utils.long_term_memory import edit_memory
+        success = edit_memory(index, data, path=self.memory_path)
+        return "memory updated" if success else "memory index out of range"
 
     def get_advice(self):
       """Return a random piece of advice from the API Ninjas service."""

--- a/Wheatly/python/src/llm/llm_client_utils.py
+++ b/Wheatly/python/src/llm/llm_client_utils.py
@@ -267,6 +267,20 @@ def build_tools():
                 "additionalProperties": False
             }
         },
+        {
+            "type": "function",
+            "name": "edit_long_term_memory",
+            "description": "Replace a memory entry by index with new JSON data.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "index": {"type": "integer"},
+                    "data": {"type": "object"}
+                },
+                "required": ["index", "data"],
+                "additionalProperties": False
+            }
+        },
         # Tool for persisting long term memory. Memory retrieval happens automatically.
     ]
     #print(tools)

--- a/Wheatly/python/src/main.py
+++ b/Wheatly/python/src/main.py
@@ -118,6 +118,9 @@ def initialize_assistant(config):
     # Initialize core components
     manager = ConversationManager(max_memory=max_memory)
     gpt_client = GPTClient(model=gpt_model)
+    # Fetch long term memory once at startup
+    initial_memory = Functions().read_long_term_memory()
+    manager.update_memory(f"LONG TERM MEMORY:\n{initial_memory}")
     stt_engine = SpeechToTextEngine()
     tts_engine = TextToSpeechEngine()
     import sys
@@ -271,7 +274,7 @@ def run_tool_workflow(manager: ConversationManager, gpt_client: GPTClient, queue
 
         # Always fetch memory before running tools and update memory message
         mem_result = Functions().read_long_term_memory()
-        manager.update_memory(str(mem_result))
+        manager.update_memory(f"LONG TERM MEMORY:\n{mem_result}")
 
         if not workflow:
             return

--- a/Wheatly/python/src/test.py
+++ b/Wheatly/python/src/test.py
@@ -125,14 +125,19 @@ class TestConversationManagerFunctionality(ColorfulTestCase):
 
 class TestLongTermMemory(ColorfulTestCase):
     def test_memory_read_write(self):
-        from utils.long_term_memory import append_memory, read_memory
+        from utils.long_term_memory import append_memory, read_memory, edit_memory
         tmp_file = "temp_memory.json"
         if os.path.exists(tmp_file):
             os.remove(tmp_file)
         append_memory({"foo": "bar"}, path=tmp_file)
+        long_text = "x" * 300
+        append_memory({"note": long_text}, path=tmp_file)
         data = read_memory(path=tmp_file)
         self.assertIsInstance(data, list)
-        self.assertEqual(data[-1]["foo"], "bar")
+        self.assertEqual(data[-1]["note"], long_text[:197] + "...")
+        edit_memory(0, {"foo": "baz" * 100}, path=tmp_file)
+        data = read_memory(path=tmp_file)
+        self.assertEqual(data[0]["foo"], ("baz" * 100)[:197] + "...")
         os.remove(tmp_file)
 
 if __name__ == '__main__':

--- a/docs/long-term-memory.md
+++ b/docs/long-term-memory.md
@@ -5,19 +5,23 @@ Provide persistent storage so Wheatley can recall facts between sessions.
 
 ## Usage
 - The LLM invokes the `write_long_term_memory` tool with a JSON object under the `data` field.
+- To modify an existing entry the LLM can call `edit_long_term_memory` with an `index` and new `data`.
 - Stored entries accumulate in `long_term_memory.json`.
 - Memory access is silent; Wheatley no longer speaks when storing or retrieving data.
-- The assistant maintains a single memory message right after the system prompt and updates it every interaction.
+- The assistant maintains a single memory message right after the system prompt labelled **LONG TERM MEMORY** and updates it every interaction.
+- The memory is also loaded once at startup so Wheatley begins each session aware of past entries.
+- When entries are written or edited they are compressed to keep only the most important content.
 
 ## Internals
-- `utils.long_term_memory` defines `append_memory` and `read_memory`.
-- `Functions` exposes `write_long_term_memory` to the LLM.
+- `utils.long_term_memory` defines `append_memory`, `read_memory`, `edit_memory` and helper compression functions.
+- `Functions` exposes `write_long_term_memory`, `edit_long_term_memory` and `read_long_term_memory` to the LLM.
 - Tool definitions live in `llm_client_utils.build_tools()`.
 
 ## Examples
 ```python
-from utils.long_term_memory import append_memory, read_memory
+from utils.long_term_memory import append_memory, read_memory, edit_memory
 
 append_memory({"note": "Remember to buy cake"})
 print(read_memory())
+edit_memory(0, {"note": "Updated entry"})
 ```


### PR DESCRIPTION
## Summary
- support editing long term memory entries
- load memory once at startup and label memory clearly
- document new memory features
- cover edit_memory in tests
- compress memory entries when written or edited

## Testing
- `pytest -q` *(no tests discovered)*
- `python Wheatly/python/src/test.py` *(failed to import `elevenlabs` during tests)*

------
https://chatgpt.com/codex/tasks/task_e_684c190dff388330b5cb3986663494b9