### PR TITLE
Fix edit_memory behavior

### DIFF
--- a/Wheatly/python/src/utils/long_term_memory.py
+++ b/Wheatly/python/src/utils/long_term_memory.py
@@ -78,31 +78,39 @@ def append_memory(entry: Dict[str, Any], path: str = MEMORY_FILE) -> None:
 
 
 def edit_memory(index: int, entry: Dict[str, Any], path: str = MEMORY_FILE) -> bool:
-    """Replace a memory entry at ``index`` with ``entry``.
+    """Replace or append a memory entry.
+
+    If ``index`` refers to an existing item it is replaced with ``entry``.
+    Otherwise ``entry`` is appended to the end of the memory list.  This
+    behaviour avoids errors when the model attempts to edit a non-existent
+    index.
 
     Parameters
     ----------
     index:
         Zero-based list position of the entry to replace.
     entry:
-        New dictionary to store at the given index.
+        New dictionary to store at the given index or to append.
     path:
         File where the long term memory is stored.
 
     Returns
     -------
     bool
-        ``True`` if the entry was replaced, ``False`` if ``index`` was invalid.
+        ``True`` if the entry was written successfully, ``False`` on error.
     """
+
     data = read_memory(path)
     if 0 <= index < len(data):
         data[index] = _compress_entry(entry)
-        data = _optimize_memory(data)
-        try:
-            with open(path, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2)
-            return True
-        except Exception as e:
-            print(f"Failed to write memory to {path}: {e}")
-    return False
+    else:
+        data.append(_compress_entry(entry))
+    data = _optimize_memory(data)
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+        return True
+    except Exception as e:
+        print(f"Failed to write memory to {path}: {e}")
+        return False
 

--- a/docs/long-term-memory.md
+++ b/docs/long-term-memory.md
@@ -6,6 +6,7 @@ Provide persistent storage so Wheatley can recall facts between sessions.
 ## Usage
 - The LLM invokes the `write_long_term_memory` tool with a JSON object under the `data` field.
 - To modify an existing entry the LLM can call `edit_long_term_memory` with an `index` and new `data`.
+  If the index is out of range the data is appended instead of raising an error.
 - Stored entries accumulate in `long_term_memory.json`.
 - Memory access is silent; Wheatley no longer speaks when storing or retrieving data.
 - The assistant maintains a single memory message right after the system prompt labelled **LONG TERM MEMORY** and updates it every interaction.


### PR DESCRIPTION
## Summary
- fix `edit_memory` so invalid indexes append instead of erroring
- document new behaviour in long-term-memory docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c1c1f08f08330bd10a7e040b0d863