### PR TITLE
Reduce internal timing logs

### DIFF
--- a/docs/timing-logging.md
+++ b/docs/timing-logging.md
@@ -1,16 +1,18 @@
 # Timing & Logging
 
 ## Purpose
-Record execution times of key functionalities for debugging and performance tuning.
+Record execution times of long running external operations for debugging and performance tuning.
 
 ## Usage
-- Call `record_timing(name, start)` with a `time.time()` start timestamp when an operation finishes.
+- Timings are collected only for expensive external calls such as speech recognition, text generation and text to speech.
+- Call `record_timing(name, start)` with a `time.time()` start timestamp when one of these operations finishes.
 - Launch the assistant with `--export-timings` to persist timings to `timings.json` on shutdown.
 
 ## Internals
 - Uses a global in-memory list `timings` stored in `utils/timing_logger.py`.
 - Each entry contains the functionality name, start and end timestamps, and the duration in milliseconds.
 - `export_timings()` writes the list to a JSON file.
+- Only the LLM request/response, ElevenLabs TTS generation and Whisper transcription functions invoke `record_timing`.
 
 ## Examples
 ```python


### PR DESCRIPTION
## Summary
- streamline timing logging by removing short internal measurements
- keep timing docs up to date

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853ac445d5c8330aca1cf0679154c60