### PR TITLE
Separate timing for TTS generation and playback

### DIFF
--- a/docs/timing-logging.md
+++ b/docs/timing-logging.md
@@ -12,7 +12,7 @@ Record execution times of long running external operations for debugging and per
 - Uses a global in-memory list `timings` stored in `utils/timing_logger.py`.
 - Each entry contains the functionality name, start and end timestamps, and the duration in milliseconds.
 - `export_timings()` writes the list to a JSON file.
-- Only the LLM request/response, ElevenLabs TTS generation and Whisper transcription functions invoke `record_timing`.
+- Only the LLM request/response, ElevenLabs TTS generation **and** playback (recorded separately), and Whisper transcription functions invoke `record_timing`.
 
 ## Examples
 ```python


### PR DESCRIPTION
## Summary
- add a class docstring to `TextToSpeechEngine`
- record timing for TTS generation and for playback separately
- document that generation and playback timings are logged independently

## Testing
- `python -m py_compile `git ls-files '*.py'``

------
https://chatgpt.com/codex/tasks/task_e_6853aeac6c0083309c88d783939abcbc