### PR TITLE
Simplify Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Wheatley Code of Conduct
+
+This project is maintained by a single developer. Please keep all discussions friendly and constructive. Harassment, hate speech, or personal attacks have no place here.
+
+If you encounter problematic behavior, contributions may be removed at my discretion. To report issues or ask questions, email contact@example.com.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to Wheatley
+
+Thank you for considering contributing to Wheatley! This project is still evolving and there are many rough edges to polish. We welcome community contributions of all kinds. Before submitting a pull request, please follow these guidelines to ensure a smooth development process.
+
+## Getting Started
+
+1. **Fork the repository** and create your branch from `main`.
+2. **Install dependencies** using the helper script:
+
+   ```bash
+   python install_prerequisites.py
+   ```
+   This installs the packages listed in `wheatley/requirements.txt`.
+3. **Run the tests** to make sure everything works:
+
+   ```bash
+   pytest -q
+   ```
+
+## Coding Standards
+
+- Include Python docstrings for all public classes, functions, and methods.
+- Add inline comments explaining why complex logic is necessary.
+- Keep code style consistent with the existing project.
+
+## Documentation
+
+- Update or create Markdown documentation whenever you add a new feature.
+- If adding files under `docs/`, update the "Documented Features" list in `AGENTS.md`.
+
+## Pull Requests
+
+1. Ensure your branch is up to date with `main`.
+2. Provide a clear description of your changes and reference any relevant issues.
+3. Confirm that all tests pass before submitting the pull request.
+4. Be responsive to review feedback and update your PR as needed.
+
+Thank you for helping improve Wheatley! Your ideas, bug reports, and code contributions all make the project better for everyone.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Wheatley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# Wheatley
+
+Welcome to **Wheatley**, an experimental voice assistant powered by open-source
+tools. The project is a work in progress and we rely on community feedback to
+make it better. If you spot a bug or have an idea, please let us know or send a
+pull request.
+
 ## Getting Started
 
 1. Create your configuration:
@@ -32,29 +39,29 @@
   - [ ] STT streaming input transcription
   [reference](https://platform.openai.com/docs/guides/speech-to-text?lang=curl#streaming-transcriptions)
   - [ ] Stream LLM response to TTS
-  TTS does not support streaming innput there is therefore no value in streaming the LLM response to TTS.
+  TTS does not support streaming input, so there is no value in streaming the LLM response to TTS.
   [reference](https://platform.openai.com/docs/api-reference/responses-streaming)
   - [ ] Stream TTS response to speaker
   [reference](https://elevenlabs.io/docs/api-reference/streaming)
 
 ### LLM
 - [X] Add long term memory (LTM) to the LLM.
-- [ ] make a memmory store with conigurable storage prioroties, and storage timestamps.
-    - [ ] make a memmory "time out" for the LLM, so it can forget things after a certain time.
+- [ ] make a memory store with configurable storage priorities and storage timestamps.
+    - [ ] make a memory "timeout" for the LLM so it can forget things after a certain time.
 
 ### Tools
 - [ ] Add a google notes tool to the LLM.
 
 ### ideas
-    - [ ] Wifi monitoring/management
-    - [ ] remote webbhook management
+    - [ ] Wi-Fi monitoring/management
+    - [ ] remote webhook management
     - [ ] guest mode
     - [X] Proactive conversation
       - [ ] Monitoring calendar?
       - [ ] Air quality alert?
-      - [X] Sett timer for x minutes?
+      - [X] Set timer for x minutes?
     - [ ] Digital twin?
-    - [ ] Readup in another voice?
+    - [ ] Read up in another voice?
     - [ ] Self aware of mood?
     - [ ] Object spotting???
     - [X] Briefing?
@@ -66,3 +73,17 @@
 
 
 ![image](https://github.com/user-attachments/assets/8a19e5c1-a585-4bda-a584-b9c9db2b953a)
+
+## Contributing
+We know Wheatley isn't perfect—there are plenty of bugs and rough edges yet to be smoothed out. If you have ideas or fixes, please jump in! For guidelines on how to contribute, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Code of Conduct
+Please read and abide by our [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+## License
+This project is licensed under the [MIT License](LICENSE).
+
+## Attribution
+If you reuse or adapt Wheatley's code in your own projects, please keep the
+license notice intact and include a link back to this repository. Giving credit
+helps others discover the original source and keeps the community strong.


### PR DESCRIPTION
## Summary
- reduce Code of Conduct to a short, friendly policy
- keep README links to contributing and code of conduct docs
- revamp README intro and add attribution guidelines for reuse

## Testing
- `pytest -q`
- `pytest wheatley/test.py -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685a5ff6cd548330844e1a3f422b960c