### PR TITLE
Implement STT threshold calibration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ Maintain a “Documented Features” section in this file. Update whenever you a
 - [Wiering_diagram](docs/Wiering_diagram.md)
 - [personality-switcher](docs/personality-switcher.md)
 - [service-authentication](docs/service-authentication.md)
+- [stt-threshold-calibration](docs/stt-threshold-calibration.md)
 ```
 
 ---

--- a/docs/stt-threshold-calibration.md
+++ b/docs/stt-threshold-calibration.md
@@ -1,0 +1,23 @@
+# STT Threshold Calibration
+
+## Purpose
+Automatically measure ambient and speaking volume to set the speech detection threshold.
+
+## Usage
+- Runs automatically when `SpeechToTextEngine` is created if STT is enabled.
+- Blinks the microphone LED blue for 5 seconds while measuring ambient noise.
+- Then blinks red for 5 seconds while the user speaks.
+- The resulting threshold is stored in `SpeechToTextEngine.THRESHOLD`.
+
+## Internals
+- Captures audio samples using PyAudio during both measurement phases.
+- Tracks maximum amplitude for ambient and speech windows.
+- The threshold is set halfway between these maxima.
+- LED blinking uses `set_mic_led_color` via `_update_mic_led`.
+
+## Examples
+```python
+from stt.stt_engine import SpeechToTextEngine
+engine = SpeechToTextEngine()
+print(engine.THRESHOLD)
+```


### PR DESCRIPTION
## Summary
- add new documentation for STT auto threshold calibration
- list the feature in `AGENTS.md`
- calibrate STT threshold on startup and implement calibration helper

## Testing
- `python -m pytest -q` *(fails: no tests)*
- `python -m unittest discover` *(0 tests)*
- `PYTHONPATH=. python wheatley/test.py` *(failed: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a7131cbd88330afa0f7056b7691a2