### PR TITLE
Improve readability of streaming handlers

### DIFF
--- a/wheatley/utils/main_helpers.py
+++ b/wheatley/utils/main_helpers.py
@@ -1,0 +1,23 @@
+"""Helper functions for the main entrypoint."""
+
+from typing import Tuple
+
+
+def feature_summary(stt_enabled: bool, tts_enabled: bool, header: str = "Feature Status") -> str:
+    """Return a formatted feature summary string."""
+    summary = f"\n{header}:\n"
+    summary += f" - Speech-to-Text (STT): {'Active' if stt_enabled else 'Inactive'}\n"
+    summary += f" - Text-to-Speech (TTS): {'Active' if tts_enabled else 'Inactive'}\n"
+    return summary
+
+
+def authenticate_and_update_features(stt_enabled: bool, tts_enabled: bool) -> Tuple[bool, bool]:
+    """Authenticate external services and update feature flags accordingly."""
+    from service_auth import authenticate_services
+
+    service_status = authenticate_services()
+    if not service_status.get("openai"):
+        stt_enabled = False
+    if not service_status.get("elevenlabs"):
+        tts_enabled = False
+    return stt_enabled, tts_enabled


### PR DESCRIPTION
## Summary
- refactor `handle_tts_and_follow_up` and `handle_follow_up_after_stream`
- rewrite `stream_assistant_reply` with descriptive variables
- clarify `async_conversation_loop` signature

## Testing
- `python -m pytest -q`
- `python wheatley/test.py` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_685e36197af0833099cee6f9363d41b1