### PR TITLE
Fix timer and reminder events

### DIFF
--- a/wheatley/llm/llm_client.py
+++ b/wheatley/llm/llm_client.py
@@ -529,9 +529,12 @@ class Functions:
         import asyncio
         from datetime import datetime
         try:
-            from main import Event as MainEvent
-        except ImportError:
-            MainEvent = None
+            from ..main import Event as MainEvent
+        except Exception:
+            try:
+                from main import Event as MainEvent
+            except Exception:
+                MainEvent = None
 
         async def timer_task():
             await asyncio.sleep(duration)
@@ -618,7 +621,15 @@ class Functions:
         delay = (target - now).total_seconds()
         async def reminder_task():
             await asyncio.sleep(delay)
-            from main import Event as MainEvent
+            try:
+                from ..main import Event as MainEvent
+            except Exception:
+                try:
+                    from main import Event as MainEvent
+                except Exception:
+                    MainEvent = None
+            if MainEvent is None:
+                return
             reminder_event = MainEvent(
                 source="reminder",
                 payload=reason or time_str,

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -13,6 +13,7 @@ import time  # For timing actions
 import asyncio
 from dataclasses import dataclass
 from typing import Dict, Any, Optional
+from datetime import datetime
 import sys
 import argparse
 import atexit
@@ -176,10 +177,12 @@ class Event:
     source: str        # e.g. "user", "timer", "gpio", "webhook", etc.
     payload: str       # human-readable description
     metadata: Optional[Dict[str, Any]] = None
+    ts: Optional[datetime] = None
 
     def __str__(self):
         meta = f" {self.metadata}" if self.metadata else ""
-        return f"[{self.source.upper()}] {self.payload}{meta}"
+        ts = f" ({self.ts.isoformat()})" if self.ts else ""
+        return f"[{self.source.upper()}] {self.payload}{meta}{ts}"
 
 # =================== Async Event Handling ===================
 async def user_input_producer(q: asyncio.Queue):


### PR DESCRIPTION
## Summary
- include timestamps in Event dataclass
- robustly import Event in LLM client timer/reminder handlers

## Testing
- `python -m py_compile wheatley/main.py wheatley/llm/llm_client.py`

------
https://chatgpt.com/codex/tasks/task_e_685e4886b59c8330b95e391f6b556998