### PR TITLE
Improve timing instrumentation

### DIFF
--- a/wheatley/llm/llm_client.py
+++ b/wheatley/llm/llm_client.py
@@ -528,6 +528,7 @@ class Functions:
         """Schedule an async timer that posts an event when it expires. Minimal error handling, print when event is notified."""
         import asyncio
         from datetime import datetime
+        start_time = time.time()
         try:
             from ..main import Event as MainEvent
         except Exception:
@@ -539,6 +540,7 @@ class Functions:
         async def timer_task():
             await asyncio.sleep(duration)
             if MainEvent is None:
+                record_timing("timer_countdown", start_time)
                 return
             timer_event = MainEvent(
                 source="timer",
@@ -553,6 +555,8 @@ class Functions:
             if event_queue:
                 await event_queue.put(timer_event)
                 print(f"[TIMER] Timer event notified: {timer_event}")
+
+            record_timing("timer_countdown", start_time)
 
         asyncio.create_task(timer_task())
 

--- a/wheatley/main.py
+++ b/wheatley/main.py
@@ -189,7 +189,9 @@ async def user_input_producer(q: asyncio.Queue):
     """Asynchronously read user text input and push Event objects to the queue."""
     loop = asyncio.get_event_loop()
     while True:
+        wait_start = time.time()
         text = await loop.run_in_executor(None, input, "You: ")
+        record_timing("await_user_input", wait_start)
         await q.put(Event("user", text.strip(), {"input_type": "text"}))
         if text.strip().lower() == "exit":
             break


### PR DESCRIPTION
## Summary
- time periods waiting for keyboard input
- time STT waiting loops and countdown timers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e8fb32010833089bbd1823e16061d