### PR TITLE
Ensure M5 syncs with OpenRB150 regardless of boot order

### DIFF
--- a/Wheatley/ino/OpenRB150/OpenRB-150.ino
+++ b/Wheatley/ino/OpenRB150/OpenRB-150.ino
@@ -2,6 +2,7 @@
  *  OpenRB-150  ⇄  Core-2 UART bridge + multi-servo calibration demo
  *  fixed: 2025-05-21  (10 s handshake & servo-torque tweak)
  *  modified: 2025-05-23  (moved Core-2 link to Serial3 on pins D14/D13)
+ *  modified: 2025-06-30  (boot-order agnostic link; periodic SYNC support)
  ******************************************************************************/
 
 #include <Arduino.h>
@@ -58,7 +59,9 @@ const float     DXL_PROTOCOL = 2.0;         // Protocol version
 
 /* ————— CORE-2 LINK (now Serial3 / D14, D13) ————— */
 const uint32_t LINK_BAUD = 115200;          // UART baud rate
-#define HANDSHAKE_TIMEOUT_MS 10000          // Handshake timeout (ms)
+
+bool linkReady = false;                     // Has Core-2 handshake occurred?
+unsigned long lastHello = 0;                // Last time HELLO was broadcast
 
 /* ————— CALIBRATION SETTINGS ————— */
 const float STEP_DEG        = 15.0f;        // Step size for calibration (deg)
@@ -201,27 +204,7 @@ void setup()
   dxl.setPortProtocolVersion(DXL_PROTOCOL);
 
   Serial2.begin(LINK_BAUD);             // Start Core-2 link on Serial3
-
-  // --- 10 s bidirectional handshake with Core-2 ---
-  unsigned long start = millis();
-  while (millis() - start < HANDSHAKE_TIMEOUT_MS) {
-    Serial2.println("HELLO");                     // Announce ourselves
-    unsigned long sliceEnd = millis() + 300;      // Short listen window
-    while (millis() < sliceEnd) {
-      Serial2.println("HELLO");
-      if (Serial2.available() && Serial2.find("ESP32")) {
-        dryRun = false;
-        DEBUG_SERIAL.println(F("[INFO] Core-2 detected"));
-        blinkOnboardLED(3);                       // Blink onboard LED 3×
-        break;
-      }
-    }
-    if (!dryRun) break;                           // Success
-  }
-  if (dryRun) {
-    DEBUG_SERIAL.println(F("[WARN] No Core-2 response after 10 s ⇒ dry-run"));
-    return;                                       // Skip calibration in dry-run
-  }
+  Serial2.println("HELLO");             // Initial announcement
 
   // --- Probe & calibrate all servos ---
   for (uint8_t i=0;i<NUM_SERVOS;++i){
@@ -240,16 +223,32 @@ void setup()
   }
 
   printAllServoStatus();
-  sendLimitsToCore2();           // Send calibration & ping result to Core-2
 }
 
 /* --------------------- LOOP --------------------- */
 void loop()
 {
-  // Handle incoming commands from Core-2
-  if (!dryRun && Serial2.available()){
+  unsigned long now = millis();
+  // Periodically announce ourselves until handshake succeeds
+  if (!linkReady && now - lastHello > 1000) {
+    Serial2.println("HELLO");
+    lastHello = now;
+  }
+
+  // Handle incoming messages from Core-2
+  if (Serial2.available()){
     String msg = Serial2.readStringUntil('\n'); msg.trim();
-    if (msg.startsWith("MOVE_SERVO")) handleMoveServoCommand(msg);
+    if (msg.startsWith("ESP32")) {
+      linkReady = true;
+      dryRun = false;
+      Serial2.println("HELLO");
+      sendLimitsToCore2();
+      blinkOnboardLED(3);
+    } else if (msg.startsWith("SYNC")) {
+      sendLimitsToCore2();
+    } else if (!dryRun && msg.startsWith("MOVE_SERVO")) {
+      handleMoveServoCommand(msg);
+    }
   }
 
   // Demo: sweep first servo back and forth twice, then turn on LED


### PR DESCRIPTION
## Summary
- Make OpenRB150 repeatedly broadcast `HELLO` and answer `ESP32`/`SYNC` commands so it can act as the source of truth even if devices boot at different times
- Add periodic `SYNC` requests from the M5Stack Core2 to refresh calibration data
- Track sync timings so both boards stay aligned

## Testing
- `arduino-cli compile Wheatley/ino/OpenRB150` *(fails: command not found)*
- `sudo apt-get install -y -qq arduino-cli` *(fails: Unable to locate package arduino-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68b6bc8f9c3083308aeb802e71f81d17