### PR TITLE
Play greeting after hotword

### DIFF
--- a/wheatley/audio/hotword_greetings/README.md
+++ b/wheatley/audio/hotword_greetings/README.md
@@ -1,0 +1,3 @@
+Place MP3 files containing short greeting phrases in this directory.
+When Wheatley detects its hotword, one of these files will be chosen at random
+and played before listening for user input.


### PR DESCRIPTION
## Summary
- Play a random pre-recorded greeting after hotword detection
- Document directory for hotword greeting audio files

## Testing
- `flake8` *(fails: E501 line too long in existing files)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6e1b13e988330be57401a9348f20c