### PR TITLE
Improve timing instrumentation and logging

### DIFF
--- a/wheatley/utils/timing_logger.py
+++ b/wheatley/utils/timing_logger.py
@@ -7,6 +7,8 @@ import datetime as _dt
 import json
 import os
 import threading
+import logging
+from contextlib import contextmanager, asynccontextmanager
 from typing import List, Dict, Any
 
 # Central in-memory store for timing entries
@@ -14,6 +16,7 @@ from typing import List, Dict, Any
 timings: List[Dict[str, Any]] = []
 # Lock to ensure thread-safe writes to the timings list
 _timings_lock = threading.Lock()
+_log = logging.getLogger(__name__)
 
 
 def clear_timings(path: str = "timings.json") -> None:
@@ -54,12 +57,33 @@ def record_timing(name: str, start: float) -> None:
     }
     with _timings_lock:
         timings.append(entry)
+    _log.info("Timing %s took %sms", name, entry["durationMs"])
+
+
+@contextmanager
+def time_block(name: str):
+    """Context manager to time a code block and record the duration."""
+    start = time.time()
+    try:
+        yield
+    finally:
+        record_timing(name, start)
+
+
+@asynccontextmanager
+async def async_time_block(name: str):
+    """Async context manager variant of :func:`time_block`."""
+    start = time.time()
+    try:
+        yield
+    finally:
+        record_timing(name, start)
 
 
 def export_timings(path: str = "timings.json") -> None:
     """Write accumulated timings to ``path`` in JSON format."""
     print(f"Exporting timings to {path}...")
     with _timings_lock:
-        data = list(timings)
+        data = sorted(timings, key=lambda x: x["startTime"])
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)


### PR DESCRIPTION
## Summary
- add logging and context manager utilities for timing measurements
- capture tool, response, and full-turn durations in conversation loop
- sort exported timing data chronologically

## Testing
- `python -m pytest`
- `python -m py_compile wheatley/utils/timing_logger.py wheatley/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7fe9d0de48330a23cd9bd4f780d7e